### PR TITLE
Exclude 'type' from keys fileds

### DIFF
--- a/shared/lib.js
+++ b/shared/lib.js
@@ -26,7 +26,7 @@ SimpleSchema.prototype.i18n = function(jsonPath, defaults) {
     schema[key].autoform = schema[key].autoform || {};
 
     if (typeof keys == 'object') {
-      _.each(_.omit(keys, 'label', 'options'), function(v, k) {
+      _.each(_.omit(keys, 'label', 'options', 'type'), function(v, k) {
         schema[key].autoform[k] = schema[key].autoform[k] || function() {
           return getKeys(jsonPath, key)[k] || (defaults[k] || '');
         };


### PR DESCRIPTION
Type autoform attribute never needs to be translated.
And if  there is a field named "type" in someone's schema, it would cause conflict, if we did not exclude it here.